### PR TITLE
Support applying outlines to individual objects

### DIFF
--- a/threejs/src/index.js
+++ b/threejs/src/index.js
@@ -10,7 +10,6 @@ import { CustomOutlinePass } from "./CustomOutlinePass.js";
 import DragAndDropModels from "./DragAndDropModels.js";
 
 const GUI = dat.GUI;
-window.THREE = THREE;
 
 // Init scene
 const camera = new THREE.PerspectiveCamera(
@@ -19,88 +18,47 @@ const camera = new THREE.PerspectiveCamera(
   0.1,
   1000
 );
-window.camera = camera;
 camera.position.set(1, 1, -2);
 const scene = new THREE.Scene();
-window.scene = scene;
 const renderer = new THREE.WebGLRenderer({
   canvas: document.querySelector("canvas"),
 });
 renderer.setSize(window.innerWidth, window.innerHeight);
-//renderer.autoClearDepth = false;
 const light = new THREE.DirectionalLight(0xffffff, 1);
 scene.add(light);
 light.position.set(1.7, 1, -1);
 
-// Set up post processing
-// Create a render target that holds a depthTexture so we can use it in the outline pass
-// See: https://threejs.org/docs/index.html#api/en/renderers/WebGLRenderTarget.depthBuffer
-const depthTexture = new THREE.DepthTexture();
 const renderTarget = new THREE.WebGLRenderTarget(
   window.innerWidth,
-  window.innerHeight,
-  {
-    depthTexture: depthTexture,
-    depthBuffer: true,
-  }
+  window.innerHeight
 );
 
+// Regular scene render pass. This is step 1 in the pipeline described in CustomOutlinePass.js
 const composer = new EffectComposer(renderer, renderTarget);
-
-// Render pass for objects that won't have outline
-// const passNoOutlines = new RenderPass(scene, camera);
-// passNoOutlines.oldRender = passNoOutlines.render;
-// passNoOutlines.render = function(renderer, writeBuffer, readBuffer) {
-//   this.oldRender(renderer, writeBuffer, readBuffer);
-// }
-// composer.addPass(passNoOutlines);
-
-// Render pass for objects with outline
 const pass = new RenderPass(scene, camera);
 composer.addPass(pass);
-pass.oldRender = pass.render;
-pass.render = function(renderer, writeBuffer, readBuffer) {
-  scene.traverse( function( node ) {
-    // We want objects that DO have outline 
-    // to appear in the color buffer here
-    // but NOT in the depth buffer
-    // SO we keep them visible but turn off depth write
-        if (node.applyOutline == true && node.type == 'Mesh') {
-          node.oldDepthWriteValue = node.material.depthWrite;
-          node.material.depthWrite = false;
-        }
-    });
-
-  this.oldRender(renderer, writeBuffer, readBuffer);
-
-  scene.traverse( function( node ) {
-        if (node.applyOutline == true && node.type == 'Mesh' && node.oldDepthWriteValue != undefined) {
-          node.material.depthWrite = node.oldDepthWriteValue;
-        }
-    });
-}
 
 // Outline pass.
 const customOutline = new CustomOutlinePass(
   new THREE.Vector2(window.innerWidth, window.innerHeight),
   scene,
-  camera,
-  depthTexture
+  camera
 );
 composer.addPass(customOutline);
 
 // Antialias pass.
 const effectFXAA = new ShaderPass(FXAAShader);
-const pixelRatio = renderer.getPixelRatio();
 effectFXAA.uniforms["resolution"].value.set(
-  1 / window.innerWidth * pixelRatio,
-  1 / window.innerHeight * pixelRatio
+  1 / window.innerWidth,
+  1 / window.innerHeight
 );
 composer.addPass(effectFXAA);
 
 // Load model
 const loader = new GLTFLoader();
 loader.load("box.glb", (gltf) => {
+  // Create a second mesh to test 
+  // selectively applying outline effect
   const mesh1 = gltf.scene; scene.add(mesh1);
 
   const mesh2 = mesh1.clone(); scene.add(mesh2);
@@ -164,7 +122,7 @@ gui
     Outlines: 0,
     "Original scene": 1,
     "Depth buffer": 2,
-    "Original depth": 5,
+    "Non-outlines depth": 5,
     "Normal buffer": 3,
     "Outlines only": 4,
   })


### PR DESCRIPTION
This PR adds support for applying the outline to individual objects. It is not intended to be merged because doing this requires an additional render pass. 

![outline_selected](https://user-images.githubusercontent.com/1711126/124299527-87999c80-db2b-11eb-98e6-117335fbde8a.gif)

To apply the outline on an object, enable it with:

```javascript
mesh.traverse(node => node.applyOutline = true);
```

### How it works

For reference, here is the original pipeline described here: https://omar-shehata.medium.com/how-to-render-outlines-in-webgl-8253c14724f9

![image](https://user-images.githubusercontent.com/1711126/124299585-997b3f80-db2b-11eb-8dce-08cc5baa0baf.png)

To apply outlines selectively, we need to create normal & depth buffers that ONLY include the outlined object(s). However, the original scene buffer still needs to include all the objects. In addition, the final outline must be occluded by objects in front of it, even if they do not have outlines applied.

My initial approach was to make render pass 2 only include the outlined objects, and use the depth & normal buffers from that. This works and does not add any additional render passes, but the final outline can be "seen through" objects in front it, because then the normal buffer that is used to compute the outlines doesn't include any foreground cubes to occlude it.

To fix this, we add an additional render pass to get a depth buffer with just the objects that do NOT have an outline on them. We then use this to apply a manual depth test in the shader:

```glsl
// If the depth of the current object is greater
// than an object without outlines
// that means further away from the camera, so the outline shouldn't be visible here
if ( depth > nonOutlinesDepth ) {
	outline = 0.0;
}
```

The new render pipeline is shown below, including snapshots of what each buffer looks like:

![rendering_diagram](https://user-images.githubusercontent.com/1711126/124300415-8d43b200-db2c-11eb-9fc1-a485ee967529.png)
